### PR TITLE
DSND-2491: Remove CERT22 and RR08 from form blocklist.

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/filinghistory/utils/FormTypeService.java
+++ b/src/main/java/uk/gov/companieshouse/api/filinghistory/utils/FormTypeService.java
@@ -346,7 +346,6 @@ public class FormTypeService {
         list.add("RR05");
         list.add("RR06");
         list.add("RR07");
-        list.add("RR08");
         list.add("RR09");
         list.add("RR10");
         list.add("AUDR");
@@ -355,7 +354,6 @@ public class FormTypeService {
         list.add("CERT1");
         list.add("CERT11");
         list.add("CERT2");
-        list.add("CERT22");
         list.add("CERT23");
         list.add("CERT24");
         list.add("CERT4");

--- a/src/test/java/uk/gov/companieshouse/api/filinghistory/utils/FormTypeServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/filinghistory/utils/FormTypeServiceTest.java
@@ -18,7 +18,7 @@ class FormTypeServiceTest {
     @Test
     void shouldBuildBlockListOfCorrectSize() {
         List<String> actual = FormTypeService.getBlockList();
-        assertEquals(347, actual.size());
+        assertEquals(345, actual.size());
     }
 
     @ParameterizedTest


### PR DESCRIPTION
* CERT22 and RR08 forms removed as per the ticket description.

[DSND-2491](https://companieshouse.atlassian.net/browse/DSND-2491)

[DSND-2491]: https://companieshouse.atlassian.net/browse/DSND-2491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ